### PR TITLE
Elastic has OpenProcess events

### DIFF
--- a/EDR_telem.json
+++ b/EDR_telem.json
@@ -25,7 +25,7 @@
     "Telemetry Feature Category":null,
     "Sub-Category":"Process Access",
     "CrowdStrike":"Yes",
-    "Elastic":"No",
+    "Elastic":"Yes",
     "LimaCharlie":"Yes",
     "MDE":"Yes",
     "Sentinel One":"Yes",


### PR DESCRIPTION
## Description

Elastic Defend includes OpenProcess (and OpenThread) events.

The primary relevant fields are -
 * `process.Ext.api.name`
 * `process.Ext.api.parameters.desired_access[]`
 * `process.Ext.api.parameters.handle_type`
 * `Target.process.pid`
 * `process.thread.Ext.call_stack[]`

Here is a [credential_access_lsass_openprocess_api](https://github.com/elastic/detection-rules/blob/8ef2f6557be603b5d1d30278a2dfe8f93c7c31d0/rules/windows/credential_access_lsass_openprocess_api.toml) detection rule written using these events. And here is a [screenshot](https://user-images.githubusercontent.com/30202999/232610315-b80350b9-61f7-4959-b67b-b9331c1dfeae.png) of a sample event.
