### PR TITLE
Carbon Black Cloud - EDR SysOps Update

### DIFF
--- a/EDR_telem.json
+++ b/EDR_telem.json
@@ -926,7 +926,7 @@
   {
     "Telemetry Feature Category":"EDR SysOps",
     "Sub-Category":"Agent Start",
-    "Carbon Black":"No",
+    "Carbon Black":"Yes",
     "Cortex XDR":"Partially",
     "CrowdStrike":"Yes",
     "Cybereason":"Yes",
@@ -948,7 +948,7 @@
   {
     "Telemetry Feature Category":null,
     "Sub-Category":"Agent Stop",
-    "Carbon Black":"No",
+    "Carbon Black":"Yes",
     "Cortex XDR":"Yes",
     "CrowdStrike":"Yes",
     "Cybereason":"Yes",
@@ -970,7 +970,7 @@
   {
     "Telemetry Feature Category":null,
     "Sub-Category":"Agent Install",
-    "Carbon Black":"No",
+    "Carbon Black":"Yes",
     "Cortex XDR":"Yes",
     "CrowdStrike":"No",
     "Cybereason":"Yes",
@@ -992,7 +992,7 @@
   {
     "Telemetry Feature Category":null,
     "Sub-Category":"Agent Uninstall",
-    "Carbon Black":"No",
+    "Carbon Black":"Yes",
     "Cortex XDR":"Yes",
     "CrowdStrike":"Yes",
     "Cybereason":"Yes",
@@ -1014,7 +1014,7 @@
   {
     "Telemetry Feature Category":null,
     "Sub-Category":"Agent Keep-Alive",
-    "Carbon Black":"No",
+    "Carbon Black":"Yes",
     "Cortex XDR":"Yes",
     "CrowdStrike":"Yes",
     "Cybereason":"Yes",
@@ -1036,7 +1036,7 @@
   {
     "Telemetry Feature Category":null,
     "Sub-Category":"Agent Errors",
-    "Carbon Black":"No",
+    "Carbon Black":"Yes",
     "Cortex XDR":"Yes",
     "CrowdStrike":"Yes",
     "Cybereason":"No",

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ For more details, you can refer to the [Pull Request #61](https://github.com/tsa
 | 5       | Trellix                 | 30.6       |
 | 6       | Harfanglab                 | 30.45       |
 | 7       | Cortex XDR                 | 29.65       |
-| 8       | LimaCharlie                 | 29.25       |
-| 9       | Trend Micro                 | 28.85       |
-| 10       | ESET Inspect                 | 28.1       |
-| 11       | Qualys                 | 27.45       |
-| 12       | Elastic                 | 26.35       |
+| 8       | Elastic                 | 29.35       |
+| 9       | LimaCharlie                 | 29.25       |
+| 10       | Trend Micro                 | 28.85       |
+| 11       | ESET Inspect                 | 28.1       |
+| 12       | Qualys                 | 27.45       |
 | 13       | Cybereason                 | 25.65       |
 | 14       | Symantec SES Complete                 | 24.3       |
 | 15       | FortiEDR                 | 23.9       |

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ For more details, you can refer to the [Pull Request #61](https://github.com/tsa
 | 14       | Symantec SES Complete                 | 24.3       |
 | 15       | FortiEDR                 | 23.9       |
 | 16       | Sysmon                 | 23.2       |
-| 17       | WatchGuard                 | 20.9       |
-| 18       | Carbon Black                 | 20.1       |
+| 17       | Carbon Black                 | 22.7       |
+| 18       | WatchGuard                 | 20.9       |
 
 
 ## EDR Telemetry Table


### PR DESCRIPTION
PR to update the EDR SysOps verdict for Carbon Black. This was also discussed beforehand with Kostas.

This was tested with Carbon Black Cloud on a Windows 11 VM.

In Carbon Black Cloud, the Endpoints page provide multiple information which meets the requirements for the following sub-categories:

- Agent Start - The "Last check-in time" means the Agent checked-in and is therefore, started
- Agent Stop - The "Last check-in time" means the Agent checked-in and if it has not in a while, means that it's therefore stopped or the host (endpoint) is offline
- Agent Install - The "Registered" date/time is noted for all sensors
- Agent Uninstall - The "Last check-in time" will be updated to the timestamp of the manual uninstall launched from the host (endpoint) directly and the agent status will be changed to "Deregistered". Similar behavior if you launch the uninstall command from the console. An entry is also added to the console's Audit Log.
- Agent Keep-Alive - The "Last check-in time" means the Agent checked-in and is therefore, active
- Agent Errors - The Endpoints page will show when an Agent is in Bypass (no monitoring, no protection) for various reasons, including missing configuration, prerequisite or errors on the host side. Even when it's in Bypass because the Agent is currently being updated

Various screenshots supporting these verdicts:

![image](https://github.com/user-attachments/assets/f3a1ba7e-36bc-4563-aee0-b06fca6e992b)
![image](https://github.com/user-attachments/assets/dd1a3276-806c-49ab-b800-78072501caf1)
![image](https://github.com/user-attachments/assets/8d91b547-ad6e-4c57-a2b4-9f4004e5fcac)
![image](https://github.com/user-attachments/assets/cb593c07-b862-4cca-af40-19673ec38d57)