### PR TITLE
Add Library/Module Loaded subcategory to macOS telemetry

### DIFF
--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -26,6 +26,19 @@
     "Unnamed: 10": null
   },
   {
+    "Telemetry Feature Category": null,
+    "Sub-Category": "Library/Module Loaded",
+    "Phorion": "No",
+    "BitDefender": "No",
+    "CrowdStrike": "No",
+    "ESET Inspect": "No",
+    "Elastic": "Yes",
+    "LimaCharlie": "No",
+    "MDE": "No",
+    "Qualys": "No",
+    "Unnamed: 10": null
+  },
+  {
     "Telemetry Feature Category": "File Activity",
     "Sub-Category": "File Creation",
     "Phorion": "Yes",

--- a/Tools/compare.py
+++ b/Tools/compare.py
@@ -109,6 +109,7 @@ MACOS_CATEGORIES_VALUED = {
     # Process Activity
     "Process Creation": 1.0,
     "Process Termination": 0.5,
+    "Library/Module Loaded": 1.0,
     # File Activity
     "File Creation": 1.0,
     "File Modification": 1.0,

--- a/partially_value_explanations_macOS.json
+++ b/partially_value_explanations_macOS.json
@@ -20,6 +20,16 @@
     "MDE": ""
   },
   {
+    "Telemetry Feature Category": null,
+    "Sub-Category": "Library/Module Loaded",
+    "LimaCharlie": "",
+    "Elastic": "",
+    "BitDefender": "",
+    "Qualys": "",
+    "CrowdStrike": "",
+    "MDE": ""
+  },
+  {
     "Telemetry Feature Category": "File Activity",
     "Sub-Category": "File Creation",
     "LimaCharlie": "",


### PR DESCRIPTION
## Summary

Adds a new "Library/Module Loaded" subcategory under Process Activity in the macOS telemetry matrix. This tracks dylib/shared library load events, a key data source for detecting dylib hijacking, dylib proxying, and DYLD_INSERT_LIBRARIES injection.

The Windows matrix already includes "Image/Library Loaded" under Process Activity. This adds the macOS equivalent.

### Current vendor support

- **Elastic**: Yes. Collected via ESF events since Elastic Defend 8.11.0, normalized as `event.category: library` and `event.action: load` on `logs-endpoint.events.library*`. Enabled by default when File event collection is active in the integration policy.

### Evidence

- Security Labs blog with library load event examples: https://www.elastic.co/security-labs/sinking-macos-pirate-ships
- Endpoint behavioral rules using this data source:
  - [Dylib Loaded by Process in Suspicious Location](https://github.com/elastic/protections-artifacts/blob/278054cb0e90dca20d6fe06f63cce6600902d50d/behavior/rules/macos/defense_evasion_dylib_loaded_by_process_in_suspicious_location.toml)
  - [Suspicious Dylib Load from Temporary Directory](https://github.com/elastic/protections-artifacts/blob/278054cb0e90dca20d6fe06f63cce6600902d50d/behavior/rules/macos/execution_suspicious_dylib_load_from_temporary_directory.toml)
  - [Python Library Load and Delete](https://github.com/elastic/protections-artifacts/blob/278054cb0e90dca20d6fe06f63cce6600902d50d/behavior/rules/macos/defense_evasion_python_library_load_and_delete.toml)
  - [Unusual Dylib Load from Users Shared Directory](https://github.com/elastic/protections-artifacts/blob/278054cb0e90dca20d6fe06f63cce6600902d50d/behavior/rules/macos/defense_evasion_unusual_dylib_load_from_users_shared_directory.toml)
  - [Dock Tile Plug-in Load](https://github.com/elastic/protections-artifacts/blob/278054cb0e90dca20d6fe06f63cce6600902d50d/behavior/rules/macos/persistence_dock_tile_plug_in_load.toml)
  - [In-Memory JXA Execution via ScriptingAdditions](https://github.com/elastic/protections-artifacts/blob/278054cb0e90dca20d6fe06f63cce6600902d50d/behavior/rules/macos/defense_evasion_in_memory_jxa_execution_via_scriptingadditions.toml)

## Files changed
- `EDR_telem_macOS.json` - new subcategory under Process Activity
- `partially_value_explanations_macOS.json` - matching entry added
- `Tools/compare.py` - scoring weight added (1.0, consistent with Windows/Linux)