### PR TITLE
Update EDR_telem_mac.json - Uptycs - User & Session Activity

### DIFF
--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -101,6 +101,7 @@
     "LimaCharlie": "Yes",
     "MDE": "Yes",
     "Qualys": "No",
+    "Uptycs": "Yes",
     "Unnamed: 10": null
   },
   {
@@ -114,6 +115,7 @@
     "LimaCharlie": "Yes",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "Yes",
     "Unnamed: 10": null
   },
   {
@@ -127,6 +129,7 @@
     "LimaCharlie": "No",
     "MDE": "Yes",
     "Qualys": "No",
+    "Uptycs": "Yes",
     "Unnamed: 10": null
   },
   {
@@ -140,6 +143,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -153,6 +157,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -166,6 +171,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "Yes",
     "Unnamed: 10": null
   },
   {


### PR DESCRIPTION
# EDR Telemetry Pull Request

## Contribution Details

This PR updates the macOS telemetry data for Uptycs covering the **User & Session Activity** category, including User Logon, User Logoff, Logon Failed, Screen Lock, Screen Unlock, and Privilege Escalation (sudo etc.). Results are `Yes` for Logon, Logoff, Logon Failed, and Privilege Escalation. Screen Lock and Screen Unlock are confirmed `No`.

### Telemetry Validation

All sub-categories were validated by running the macOS EDR telemetry generation script and querying the relevant tables in Uptycs.

**User Logon** — queried via:
```
select ue.upt_time, ue.message, ue.pid, ue.login_name, ue.uname, ue.session_id, ue.upt_hostname
from user_events ue
where upt_asset_id='564d7bfc-4c1f-2d22-c3ab-3b1fd3e60ea3'
  and upt_day >= CAST(date_format((CURRENT_DATE - INTERVAL '1' DAY), '%Y%m%d') AS INT)
  and (message like 'user authentication:Successful:%' or message like 'OpenSSH login:Successful%')
order by upt_time DESC
```

<img width="1177" height="198" alt="image" src="https://github.com/user-attachments/assets/8cf09d3d-0c6a-47f9-b388-ca5835d15c7d" />

**User Logoff** — queried via:
```
select ue.upt_time, ue.message, ue.pid, ue.login_name, ue.uname, ue.session_id, ue.upt_hostname
from user_events ue
where upt_asset_id='564d7bfc-4c1f-2d22-c3ab-3b1fd3e60ea3'
  and upt_day >= CAST(date_format((CURRENT_DATE - INTERVAL '100' DAY), '%Y%m%d') AS INT)
  and message like 'logout%'
order by upt_time DESC
```

<img width="1177" height="148" alt="image" src="https://github.com/user-attachments/assets/96f02e60-e287-46d9-b357-a317c0452404" />

**Logon Failed** — queried via:
```
select ue.upt_time, ue.message, ue.pid, ue.login_name, ue.uname, ue.session_id, ue.upt_hostname
from user_events ue
where upt_asset_id='564d7bfc-4c1f-2d22-c3ab-3b1fd3e60ea3'
  and upt_day >= CAST(date_format((CURRENT_DATE - INTERVAL '1' DAY), '%Y%m%d') AS INT)
  and (message like 'user authentication:Failed:%' or message like 'OpenSSH login:Failed:%')
order by upt_time DESC
```

<img width="1192" height="311" alt="image" src="https://github.com/user-attachments/assets/8478abba-781c-4d26-991c-ffa5989d65fe" />

**Screen Lock** — `No`. Uptycs does not surface a dedicated screen lock event on macOS at this point in time. 

**Screen Unlock** — `No`. As above, there is no dedicated screen unlock event available in Uptycs on macOS at this point in time.

**Privilege Escalation (sudo etc.)** — queried via:

Privilege escalation is identified when `login_name` (the original user) differs from `uname` (the effective user running the process). For example, `login_name = user` and `uname = root` indicate the user escalated privileges via sudo.
```
select upt_time, pid, path, mode, cmdline, env, euid, egid, login_name, uname
from process_events
where upt_day >= CAST(date_format(current_date - INTERVAL '1' day, '%Y%m%d') AS INTEGER)
  and upt_asset_id='564d1969-51b0-d23e-47e0-d0658d09af0d'
order by upt_time DESC
limit 100
```

<img width="1304" height="260" alt="image" src="https://github.com/user-attachments/assets/32f39b72-6eda-4025-a423-3f7a5801eb78" />

Documentation or Evidence:
- [ ] Official documentation (link: )
- [x] Screenshots attached
- [ ] Sanitized logs provided
- [ ] Private documentation (will share confidentially)

## Type of Contribution

- [ ] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information
- EDR Product Name: Uptycs
- EDR Version: 5.19
- Operating System(s) Tested: macOS

### Testing Methodology

The macOS EDR telemetry generation script was run on a managed macOS host enrolled in Uptycs. Logon, logoff, and failed logon events were captured via the `user_events` table by filtering on known message patterns. Privilege escalation was identified via the `process_events` table by comparing `login_name` and `uname` fields — a mismatch (e.g. original user vs. root) indicates a sudo-style escalation. Screen Lock and Screen Unlock were investigated, but no telemetry is currently available in tables; these are recorded as `No`.

## Additional Notes

Screen Lock and Screen Unlock (`No`) are not surfaced by Uptycs on macOS in version 5.19. The `user_events` table is the primary data source for logon-related activity, while `process_events` is used for detecting privilege escalation. No configuration changes were required for any of these sub-categories.