### PR TITLE
Update EDR_telem_mac.json - Uptycs - Network Activity

### DIFF
--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -192,6 +192,7 @@
     "LimaCharlie": "Yes",
     "MDE": "Yes",
     "Qualys": "Yes",
+    "Uptycs":"Yes",
     "Unnamed: 10": null
   },
   {
@@ -205,6 +206,7 @@
     "LimaCharlie": "Yes",
     "MDE": "Yes",
     "Qualys": "No",
+    "Uptycs":"Via EnablingTelemetry",
     "Unnamed: 10": null
   },
   {
@@ -218,6 +220,7 @@
     "LimaCharlie": "Yes",
     "MDE": "Partially",
     "Qualys": "No",
+    "Uptycs":"Yes",
     "Unnamed: 10": null
   },
   {


### PR DESCRIPTION
# EDR Telemetry Pull Request

## Contribution Details

This PR updates the macOS telemetry data for Uptycs, covering the **Network Activity** category, including Network Connection, Network Socket Listen, and DNS Query. Network Connection and DNS Query are confirmed `Yes`. Network Socket Listen is confirmed `Via EnablingTelemetry` — a configuration change is required to surface timely data.

### Telemetry Validation

All three Network Activity sub-categories were validated by running the macOS EDR telemetry generation script and querying the relevant tables in Uptycs.

**Network Connection** — queried via:
```
select upt_time, action, pid, cmdline, path, local_address, local_port, remote_address, remote_port, status
from socket_events
where upt_day >= CAST(date_format((CURRENT_DATE - INTERVAL '0' DAY), '%Y%m%d') AS INT)
  and upt_asset_id='564d1969-51b0-d23e-47e0-d0658d09af0d'
  and remote_address='8.8.8.8'
  and remote_port=53
order by upt_time DESC
limit 1000
```

<img width="1089" height="135" alt="image" src="https://github.com/user-attachments/assets/935c39c9-ac59-45d5-a126-81e4f63bcfd2" />

**Network Socket Listen** — `Via EnablingTelemetry`. Data is available via the `listening_ports` table, however the default collection schedule of 300 seconds results in significant latency in event visibility. A configuration change reducing the schedule interval to 2 seconds is required to surface timely telemetry. Queried via:
```
SELECT upt_time, pid, port, protocol, family, address
FROM listening_ports
WHERE upt_day=20260324
  and upt_asset_id='564d1969-51b0-d23e-47e0-d0658d09af0d'
  and address='127.0.0.1'
  and port=54321
ORDER BY upt_time DESC
```

<img width="1085" height="397" alt="image" src="https://github.com/user-attachments/assets/aceb1d2d-9337-48e5-8f71-b71825853e48" />

**DNS Query** — queried via:
```
select upt_time, local, remote, question, type, answer, answers, pid, name
from dns_lookup_events
where upt_day >= CAST(date_format((CURRENT_DATE - INTERVAL '0' DAY), '%Y%m%d') AS INT)
  and upt_asset_id='564d1969-51b0-d23e-47e0-d0658d09af0d'
  and question in('apple.com','gartner.com','google.com')
order by upt_time DESC
limit 1000
```

<img width="1086" height="150" alt="image" src="https://github.com/user-attachments/assets/f016eead-3c24-4f73-aa47-4c01dd095e5c" />

Documentation or Evidence:
- [ ] Official documentation (link: )
- [x] Screenshots attached
- [ ] Sanitized logs provided
- [ ] Private documentation (will share confidentially)

## Type of Contribution

- [ ] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information
- EDR Product Name: Uptycs
- EDR Version: 5.19
- Operating System(s) Tested: macOS

### Testing Methodology

The macOS EDR telemetry generation script was run on a managed macOS host enrolled in Uptycs. Network Connection events were captured via the `socket_events` table, filtering on a known remote address and port. DNS Query events were captured via the `dns_lookup_events` table, filtering on known test domains. Network Socket Listen data is available via the `listening_ports` table, but requires a schedule change from the default 300-second interval to 2-seconds to provide timely telemetry visibility; this sub-category is therefore recorded as `Via EnablingTelemetry`.

## Additional Notes

Network Socket Listen (`Via EnablingTelemetry`) requires a collection schedule change from 300 seconds to 2 seconds in Uptycs to surface near-real-time socket listen events on macOS. No additional configuration changes were required for Network Connection or DNS Query.