### PR TITLE
Update EDR_telem_mac.json - Uptycs - System Extension & Driver

### DIFF
--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -361,6 +361,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "Yes",
     "Unnamed: 10": null
   },
   {
@@ -374,6 +375,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "Pending Response",
     "Unnamed: 10": null
   },
   {
@@ -387,6 +389,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "Pending Response",
     "Unnamed: 10": null
   },
   {
@@ -400,6 +403,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "Pending Response",
     "Unnamed: 10": null
   },
   {
@@ -413,6 +417,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "Pending Response",
     "Unnamed: 10": null
   },
   {


### PR DESCRIPTION
# EDR Telemetry Pull Request

## Contribution Details

This PR updates the macOS telemetry data for Uptycs covering the **System Extension & Driver** category, including System Extension Installed, System Extension Loaded, System Extension Uninstalled, DriverKit Extension Loaded, and Kernel Extension Loaded (legacy). System Extension Installed is confirmed `Yes`. The remaining sub-categories are recorded as `Pending Response` as the test script failed during evaluation and testing is ongoing.

### Telemetry Validation

**System Extension Installed** — queried via:
```
select upt_time, path, state, identifier, version, category, bundle_path, team
from system_extensions
where upt_day >= 20260325
  and upt_asset_id='564d1969-51b0-d23e-47e0-d0658d09af0d'
order by upt_time DESC
```

<img width="1151" height="101" alt="image" src="https://github.com/user-attachments/assets/2ea95aee-28c6-4c86-9a30-9ea7aff0e1ec" />

```
select *
from kernel_extensions
where upt_day >= 20260325
  and upt_asset_id='564d1969-51b0-d23e-47e0-d0658d09af0d'
order by upt_time DESC
```

<img width="1068" height="295" alt="image" src="https://github.com/user-attachments/assets/8bca0c0c-d853-4f05-bc1f-acc021dc260f" />

**System Extension Loaded** — `Pending Response`. The test script failed during evaluation; testing is ongoing.

**System Extension Uninstalled** — `Pending Response`. The test script failed during evaluation; testing is ongoing.

**DriverKit Extension Loaded** — `Pending Response`. The test script failed during evaluation; testing is ongoing.

**Kernel Extension Loaded (legacy)** — `Pending Response`. The test script failed during evaluation; testing is ongoing.

Documentation or Evidence:
- [ ] Official documentation (link: )
- [x] Screenshots attached
- [ ] Sanitized logs provided
- [ ] Private documentation (will share confidentially)

## Type of Contribution

- [ ] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information
- EDR Product Name: Uptycs
- EDR Version: 5.19
- Operating System(s) Tested: macOS

### Testing Methodology

The macOS EDR telemetry generation script was run on a managed macOS host enrolled in Uptycs. System Extension Installed was confirmed by querying both the `system_extensions` and `kernel_extensions` tables and observing matching events. The remaining sub-categories — System Extension Loaded, System Extension Uninstalled, DriverKit Extension Loaded, and Kernel Extension Loaded (legacy) — could not be confirmed as the test script failed during evaluation. These are recorded as `Pending Response` and will be updated in a follow-up PR once testing is complete.

## Additional Notes

System Extension Loaded, System Extension Uninstalled, DriverKit Extension Loaded, and Kernel Extension Loaded (legacy) are set to `Pending Response` due to test script failure. A follow-up PR will be submitted with the confirmed values and supporting evidence once testing is completed successfully. No configuration changes were required for System Extension Installed.