### PR TITLE
Update EDR_telem_mac.json - Uptycs - Code Signing & Trust

### DIFF
--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -426,6 +426,7 @@
     "LimaCharlie": "Yes",
     "MDE": "No",
     "Qualys": "Yes",
+    "Uptycs": "Yes",
     "Unnamed: 10": null
   },
   {
@@ -439,6 +440,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "Pending Response",
     "Unnamed: 10": null
   },
   {
@@ -452,6 +454,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "Pending Response",
     "Unnamed: 10": null
   },
   {
@@ -465,6 +468,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "Pending Response",
     "Unnamed: 10": null
   },
   {
@@ -478,6 +482,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "Pending Response",
     "Unnamed: 10": null
   },
   {
@@ -491,6 +496,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "Yes",
     "Unnamed: 10": null
   },
   {
@@ -504,6 +510,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "Yes",
     "Unnamed: 10": null
   },
   {


### PR DESCRIPTION
# EDR Telemetry Pull Request

## Contribution Details

This PR updates the macOS telemetry data for Uptycs covering the **Code Signing & Trust** category, including Binary Signature Info Recorded, Unsigned/Ad Hoc Binary Executed, Notarization Status Recorded, Quarantine Flag Set, Quarantine Flag Cleared, Gatekeeper Decision Logged, XProtect Detection Logged, and XProtect Remediation Logged. Binary Signature Info Recorded, Unsigned/Ad Hoc Binary Executed, XProtect Detection Logged, and XProtect Remediation Logged are confirmed `Yes`. Notarization Status Recorded, Quarantine Flag Set, Quarantine Flag Cleared, and Gatekeeper Decision Logged are recorded as `Pending Response` while testing and review is ongoing.

### Telemetry Validation

All sub-categories were validated or assessed by running the macOS EDR telemetry generation script and querying the relevant tables in Uptycs.

**Binary Signature Info Recorded** — queried via:
```
SELECT upt_time, path, cmdline, signed, identifier, ancestor_list
FROM process_events
WHERE upt_day=20260324
  and upt_asset_id='564d1969-51b0-d23e-47e0-d0658d09af0d'
  and cmdline like '%/usr/bin/true%'
  and signed=1
  and ancestor_list like '%CodeSignTrust%'
ORDER BY upt_time DESC
limit 1000
```

<img width="1035" height="74" alt="image" src="https://github.com/user-attachments/assets/f70c903e-f643-49b5-9a4d-f44968dea342" />

**Unsigned/Ad Hoc Binary Executed** — queried via:
```
SELECT upt_time, path, cmdline, signed, identifier, ancestor_list
FROM process_events
WHERE upt_day=20260324
  and upt_asset_id='564d1969-51b0-d23e-47e0-d0658d09af0d'
  and cmdline like '%/tmp/edr_macho_7_5e_tpb%'
  and signed=0
  and ancestor_list like '%CodeSignTrust%'
ORDER BY upt_time DESC
limit 1000
```

<img width="1035" height="74" alt="image" src="https://github.com/user-attachments/assets/1fb79859-c40b-435b-a766-27aa9c7a86bd" />

**Notarization Status Recorded** — `Pending Response`. Testing is ongoing; results are yet to be confirmed.

**Quarantine Flag Set** — `Pending Response`. Testing is ongoing; results are yet to be confirmed.

**Quarantine Flag Cleared** — `Pending Response`. Testing is ongoing; results are yet to be confirmed.

**Gatekeeper Decision Logged** — `Pending Response`. Testing is ongoing; results are yet to be confirmed.

**XProtect Detection Logged** — queried via:
```
select *
from xprotect_entries
where upt_day >= CAST(date_format(current_date - INTERVAL '1' day, '%Y%m%d') AS INTEGER)
  and upt_asset_id='564d1969-51b0-d23e-47e0-d0658d09af0d'
limit 100
```

<img width="1035" height="344" alt="image" src="https://github.com/user-attachments/assets/af83fc38-887a-46c7-bf84-3f460c56219d" />

**XProtect Remediation Logged** — `Yes`. Events are captured via the `xprotect_malware_events` table in Uptycs.

<!-- SCREENSHOT: Insert Uptycs query result for XProtect Remediation Logged here -->

Documentation or Evidence:
- [ ] Official documentation (link: )
- [x] Screenshots attached
- [ ] Sanitized logs provided
- [ ] Private documentation (will share confidentially)

## Type of Contribution

- [ ] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information
- EDR Product Name: Uptycs
- EDR Version: 5.19
- Operating System(s) Tested: macOS

### Testing Methodology

The macOS EDR telemetry generation script was run on a managed macOS host enrolled in Uptycs. Binary Signature Info Recorded and Unsigned/Ad Hoc Binary Executed were confirmed via the `process_events` table, filtering on the `signed` field and known test binary paths within the `ancestor_list`. XProtect Detection Logged was confirmed via the `xprotect_entries` table. XProtect Remediation Logged was confirmed via the `xprotect_malware_events` table. Notarization Status Recorded, Quarantine Flag Set, Quarantine Flag Cleared, and Gatekeeper Decision Logged are currently under review and recorded as `Pending Response`; these will be updated in a follow-up PR once testing is complete.

## Additional Notes

Notarization Status Recorded, Quarantine Flag Set, Quarantine Flag Cleared, and Gatekeeper Decision Logged (`Pending Response`) have not yet been confirmed and will be submitted in a follow-up PR with supporting evidence. XProtect Remediation Logged events are surfaced via the `xprotect_malware_events` table. No configuration changes were required for any of the confirmed sub-categories.