### PR TITLE
Update EDR_telem_mac.json - Uptycs - Remaining Categories (Placeholder)

### DIFF
--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -179,6 +179,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -231,6 +232,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -244,6 +246,7 @@
     "LimaCharlie": "No",
     "MDE": "Partially",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -257,6 +260,7 @@
     "LimaCharlie": "No",
     "MDE": "Partially",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -270,6 +274,7 @@
     "LimaCharlie": "No",
     "MDE": "Partially",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -283,6 +288,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -296,6 +302,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -309,6 +316,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -322,6 +330,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -335,6 +344,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -348,6 +358,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -517,6 +528,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -530,6 +542,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -543,6 +556,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -556,6 +570,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -569,6 +584,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -582,6 +598,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -595,6 +612,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -608,6 +626,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -621,6 +640,7 @@
     "LimaCharlie": "Yes",
     "MDE": "Partially",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -634,6 +654,7 @@
     "LimaCharlie": "Yes",
     "MDE": "Partially",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -647,6 +668,7 @@
     "LimaCharlie": "Yes",
     "MDE": "Yes",
     "Qualys": "Yes",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -660,6 +682,7 @@
     "LimaCharlie": "Yes",
     "MDE": "Yes",
     "Qualys": "Yes",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -673,6 +696,7 @@
     "LimaCharlie": "No",
     "MDE": "Yes",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -686,6 +710,7 @@
     "LimaCharlie": "No",
     "MDE": "Yes",
     "Qualys": "Yes",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -699,6 +724,7 @@
     "LimaCharlie": "Yes",
     "MDE": "Yes",
     "Qualys": "Yes",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -712,6 +738,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -725,6 +752,7 @@
     "LimaCharlie": "Yes",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -738,6 +766,7 @@
     "LimaCharlie": "Yes",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -751,6 +780,7 @@
     "LimaCharlie": "No",
     "MDE": "No",
     "Qualys": "No",
+    "Uptycs": "No",
     "Unnamed: 10": null
   }
 ]

--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -710,7 +710,6 @@
     "LimaCharlie": "No",
     "MDE": "Yes",
     "Qualys": "Yes",
-    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {
@@ -724,7 +723,6 @@
     "LimaCharlie": "Yes",
     "MDE": "Yes",
     "Qualys": "Yes",
-    "Uptycs": "No",
     "Unnamed: 10": null
   },
   {


### PR DESCRIPTION
# EDR Telemetry Pull Request

## Contribution Details

This PR updates the macOS telemetry data for Uptycs, covering all remaining untested categories, including Script Activity, Scheduled Task & Persistence Activity, User Account Activity, Privacy & TCC Activity, Access Activity, Process Tampering Activity, Device Activity, EDR SysOps, File Metadata, and Service Activity. All sub-categories in this PR are recorded as `No` at this point in time while the assessment is ongoing. This PR is being submitted to ensure a response exists for each outstanding category. Future updates with confirmed values and supporting evidence will be submitted in follow-up PRs as testing is completed.

### Telemetry Validation

All sub-categories below are currently under assessment. No confirmed telemetry has been identified in Uptycs on macOS for these items at this point in time.

**Script Activity**

**Script Content** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Scheduled Task & Persistence Activity**

**Scheduled Task Change (cron/at)** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Launchd Item Created** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Launchd Item Modified** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Launchd Item Deleted** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**LoginItem Created** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**LoginItem Deleted** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**User Account Activity**

**User Account Created** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**User Account Modified** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**User Account Deleted** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Group Membership Modified** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Privacy & TCC Activity**

**TCC Prompt Shown** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**TCC Decision (Allow)** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**TCC Decision (Deny)** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**TCC Policy Change** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**TCC Access Check** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Access Activity**

**Raw Device Access** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Process Access** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Process Tampering Activity**

**Process Injection Or Tampering** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Device Activity**

**External Media Mounted** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**External Media Unmounted** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**EDR SysOps**

**Agent Start** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Agent Stop** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Agent Protection Disabled Or Tamper Event** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**File Metadata**

**MD5 Available** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**SHA-256 Available** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Fuzzy Hash Available** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Service Activity**

**Service Created** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Service Modified** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

**Service Deleted** — `No`. No confirmed telemetry is currently available in Uptycs on macOS at this point in time.

Documentation or Evidence:
- [ ] Official documentation (link: )
- [ ] Screenshots attached
- [ ] Sanitized logs provided
- [ ] Private documentation (will share confidentially)

## Type of Contribution

- [ ] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information
- EDR Product Name: Uptycs
- EDR Version: 5.19
- Operating System(s) Tested: macOS

### Testing Methodology

Assessment of these sub-categories is still ongoing on a managed macOS host enrolled in Uptycs. This PR is being submitted to ensure a placeholder response exists for all outstanding categories. All sub-categories are recorded as `No` at this point in time. Follow-up PRs will be submitted with confirmed values and supporting evidence as testing is completed for each category.

## Additional Notes

This is a placeholder PR covering all remaining untested macOS telemetry categories for Uptycs. The `No` values submitted here reflect the current state of assessment and do not necessarily represent the final confirmed capability of Uptycs on macOS. Future PRs will update individual categories as testing is finalised.