### PR TITLE
Update EDR_telem_mac.json - Uptycs - File Metadata

### DIFF
--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -686,6 +686,7 @@
     "LimaCharlie": "No",
     "MDE": "Yes",
     "Qualys": "Yes",
+    "Uptycs": "Yes",
     "Unnamed: 10": null
   },
   {
@@ -699,6 +700,7 @@
     "LimaCharlie": "Yes",
     "MDE": "Yes",
     "Qualys": "Yes",
+    "Uptycs": "Yes",
     "Unnamed: 10": null
   },
   {


### PR DESCRIPTION
# EDR Telemetry Pull Request

## Contribution Details

This PR updates the macOS telemetry data for Uptycs covering the **File Metadata** category, including MD5 Available and SHA-256 Available. Both sub-categories are confirmed `Yes`.

### Telemetry Validation

Both File Metadata sub-categories were validated by querying the `process_events` table in Uptycs.

**MD5 Available** — queried via:
```
select path, identifier, md5, sha256
from process_events
where upt_day >= CAST(date_format(current_date - INTERVAL '1' day, '%Y%m%d') AS INTEGER)
  and upt_os='macOS'
```

**SHA-256 Available** — confirmed via the same query above.

<img width="1525" height="618" alt="image" src="https://github.com/user-attachments/assets/d426c781-5004-4632-90f1-c739639869a3" />

Documentation or Evidence:
- [ ] Official documentation (link: )
- [x] Screenshots attached
- [ ] Sanitized logs provided
- [ ] Private documentation (will share confidentially)

## Type of Contribution

- [ ] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information
- EDR Product Name: Uptycs
- EDR Version: 5.19
- Operating System(s) Tested: macOS

### Testing Methodology

The `process_events` table was queried on a managed macOS host enrolled in Uptycs, filtering on the current day and `upt_os='macOS'`. Both the `md5` and `sha256` columns returned populated values, confirming that both hash types are available as telemetry fields.

## Additional Notes

Both MD5 and SHA-256 are surfaced via the `process_events` table. A single query covers both sub-categories as the `md5` and `sha256` fields are columns within the same table. No configuration changes were required for either sub-category.