### PR TITLE
C-Prot macOS Agent Start

### DIFF
--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -640,7 +640,7 @@
     "Telemetry Feature Category": "EDR SysOps",
     "Sub-Category": "Agent Start",
     "BitDefender": "Yes",
-    "C-Prot": "No",
+    "C-Prot": "Yes",
     "CrowdStrike": "Yes",
     "ESET Inspect": "Yes",
     "Elastic": "Yes",


### PR DESCRIPTION
# EDR Telemetry Pull Request

## Contribution Details

This pull request updates and validates **macOS Agent Start telemetry** for the C-Prot EDR product. The contribution demonstrates that agent start events on a macOS endpoint are correctly detected and ingested into the EDR management platform.

### Telemetry Validation

This contribution meets the EDR Telemetry definition by demonstrating visibility into macOS agent start events. The telemetry captures agent startup events on the endpoint and successfully reports these events to the management console for investigation and response purposes.

Documentation or Evidence:
- [x] Screenshots attached
- [x] Sanitized logs provided
- [ ] Official documentation
- [ ] Private documentation (will share confidentially)

#### Evidence Screenshots

**Management Console Evidence**

The following screenshot confirms that the agent start telemetry is successfully received and displayed in the C-Prot Management Console (CSC).

<img width="2556" height="1165" alt="C-Prot_macOS_Agent_Start_CSC_Evidence" src="https://github.com/user-attachments/assets/dae61c63-0c5c-4bb2-86c3-aafb224d4bc2" />

---

## Type of Contribution

- [x] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information

- **EDR Product Name:** C-Prot EDR
- **EDR Version:** N/A
- **Operating System(s) Tested:** macOS

### Testing Methodology

Agent start telemetry was validated by observing the corresponding event data automatically generated upon agent startup on the macOS endpoint. The event was confirmed to be successfully ingested and displayed in the C-Prot Management Console (CSC).

## Additional Notes

All testing was performed in a controlled environment. Any sensitive information present in the screenshots has been sanitized where applicable.

[csc_telemetry_application-lifecycle-log_2026-05-11T11-40Z_2026-05-12T11-40Z.json.gz](https://github.com/user-attachments/files/27705252/csc_telemetry_application-lifecycle-log_2026-05-11T11-40Z_2026-05-12T11-40Z.json.gz)
