### PR TITLE
C-Prot macOS Agent Stop

### DIFF
--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -653,7 +653,7 @@
     "Telemetry Feature Category": null,
     "Sub-Category": "Agent Stop",
     "BitDefender": "Yes",
-    "C-Prot": "No",
+    "C-Prot": "Yes",
     "CrowdStrike": "Yes",
     "ESET Inspect": "Yes",
     "Elastic": "Yes",


### PR DESCRIPTION
# EDR Telemetry Pull Request

## Contribution Details

This pull request updates and validates **macOS Agent Stop telemetry** for the C-Prot EDR product. The contribution demonstrates that agent stop events on a macOS endpoint are correctly detected and ingested into the EDR management platform.

### Telemetry Validation

This contribution meets the EDR Telemetry definition by demonstrating visibility into macOS agent stop events. The telemetry captures agent shutdown events on the endpoint and successfully reports these events to the management console for investigation and response purposes.

Documentation or Evidence:
- [x] Screenshots attached
- [x] Sanitized logs provided
- [ ] Official documentation
- [ ] Private documentation (will share confidentially)

#### Evidence Screenshots

**Management Console Evidence**

The following screenshot confirms that the agent stop telemetry is successfully received and displayed in the C-Prot Management Console (CSC).

<img width="2554" height="1167" alt="C-Prot_macOS_Agent_Stop_CSC_Evidence" src="https://github.com/user-attachments/assets/67cad5bb-f83c-404f-a014-2b15f3e5f8c5" />

---

## Type of Contribution

- [x] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information

- **EDR Product Name:** C-Prot EDR
- **EDR Version:** N/A
- **Operating System(s) Tested:** macOS

### Testing Methodology

Agent stop telemetry was validated by observing the corresponding event data automatically generated upon agent shutdown on the macOS endpoint. The event was confirmed to be successfully ingested and displayed in the C-Prot Management Console (CSC).

## Additional Notes

All testing was performed in a controlled environment. Any sensitive information present in the screenshots has been sanitized where applicable.

[csc_telemetry_application-lifecycle-log_2026-05-11T11-41Z_2026-05-12T11-41Z.json.gz](https://github.com/user-attachments/files/27705372/csc_telemetry_application-lifecycle-log_2026-05-11T11-41Z_2026-05-12T11-41Z.json.gz)
