### PR TITLE
C-Prot macOS Screen Locked

### DIFF
--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -133,7 +133,7 @@
     "Telemetry Feature Category": null,
     "Sub-Category": "Screen Lock",
     "BitDefender": "No",
-    "C-Prot": "No",
+    "C-Prot": "Yes",
     "CrowdStrike": "No",
     "ESET Inspect": "No",
     "Elastic": "No",


### PR DESCRIPTION
# EDR Telemetry Pull Request

## Contribution Details

This pull request updates and validates **macOS Screen Locked telemetry** for the C-Prot EDR product. The contribution demonstrates that screen lock events on a macOS endpoint are correctly detected and ingested into the EDR management platform.

### Telemetry Validation

This contribution meets the EDR Telemetry definition by demonstrating visibility into macOS screen lock events. The telemetry captures screen lock events on the endpoint and successfully reports these events to the management console for investigation and response purposes.

Documentation or Evidence:
- [x] Screenshots attached
- [x] Sanitized logs provided
- [ ] Official documentation
- [ ] Private documentation (will share confidentially)

#### Evidence Screenshots

**Management Console Evidence**

The following screenshot confirms that the screen locked telemetry is successfully received and displayed in the C-Prot Management Console (CSC).

<img width="2545" height="1165" alt="C-Prot_macOS_Session_Lock_CSC_Evidence" src="https://github.com/user-attachments/assets/fb1c1b4f-e00d-4df8-89c4-7b5bdff578c9" />

---

## Type of Contribution

- [x] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information

- **EDR Product Name:** C-Prot EDR
- **EDR Version:** N/A
- **Operating System(s) Tested:** macOS

### Testing Methodology

Screen locked telemetry was validated by observing the corresponding event data automatically generated upon screen lock on the macOS endpoint. The event was confirmed to be successfully ingested and displayed in the C-Prot Management Console (CSC).

## Additional Notes

All testing was performed in a controlled environment. Any sensitive information present in the screenshots has been sanitized where applicable.

[csc_telemetry_auth-log_2026-05-11T13-02Z_2026-05-12T13-02Z.json.gz](https://github.com/user-attachments/files/27705749/csc_telemetry_auth-log_2026-05-11T13-02Z_2026-05-12T13-02Z.json.gz)
