### PR TITLE
C-Prot macOS Screen Unlocked

### DIFF
--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -146,7 +146,7 @@
     "Telemetry Feature Category": null,
     "Sub-Category": "Screen Unlock",
     "BitDefender": "No",
-    "C-Prot": "No",
+    "C-Prot": "Yes",
     "CrowdStrike": "No",
     "ESET Inspect": "No",
     "Elastic": "No",


### PR DESCRIPTION
# EDR Telemetry Pull Request

## Contribution Details

This pull request updates and validates **macOS Screen Unlocked telemetry** for the C-Prot EDR product. The contribution demonstrates that screen unlock events on a macOS endpoint are correctly detected and ingested into the EDR management platform.

### Telemetry Validation

This contribution meets the EDR Telemetry definition by demonstrating visibility into macOS screen unlock events. The telemetry captures screen unlock events on the endpoint and successfully reports these events to the management console for investigation and response purposes.

Documentation or Evidence:
- [x] Screenshots attached
- [x] Sanitized logs provided
- [ ] Official documentation
- [ ] Private documentation (will share confidentially)

#### Evidence Screenshots

**Management Console Evidence**

The following screenshot confirms that the screen unlocked telemetry is successfully received and displayed in the C-Prot Management Console (CSC).

<img width="2544" height="1164" alt="C-Prot_macOS_Session_Unlocked_CSC_Evidence" src="https://github.com/user-attachments/assets/bf37cb63-97a9-4e87-a109-667efffad1a6" />

---

## Type of Contribution

- [x] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information

- **EDR Product Name:** C-Prot EDR
- **EDR Version:** N/A
- **Operating System(s) Tested:** macOS

### Testing Methodology

Screen unlocked telemetry was validated by observing the corresponding event data automatically generated upon screen unlock on the macOS endpoint. The event was confirmed to be successfully ingested and displayed in the C-Prot Management Console (CSC).

## Additional Notes

All testing was performed in a controlled environment. Any sensitive information present in the screenshots has been sanitized where applicable.

[csc_telemetry_auth-log_2026-05-11T13-05Z_2026-05-12T13-05Z.json.gz](https://github.com/user-attachments/files/27706159/csc_telemetry_auth-log_2026-05-11T13-05Z_2026-05-12T13-05Z.json.gz)
