### PR TITLE
C-Prot macOS Logon Failed

### DIFF
--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -120,7 +120,7 @@
     "Telemetry Feature Category": null,
     "Sub-Category": "Logon Failed",
     "BitDefender": "No",
-    "C-Prot": "No",
+    "C-Prot": "Yes",
     "CrowdStrike": "Yes",
     "ESET Inspect": "No",
     "Elastic": "Yes",


### PR DESCRIPTION
# EDR Telemetry Pull Request

## Contribution Details

This pull request updates and validates **macOS Logon Failed telemetry** for the C-Prot EDR product. The contribution demonstrates that failed logon attempts on a macOS endpoint are correctly detected and ingested into the EDR management platform.

### Telemetry Validation

This contribution meets the EDR Telemetry definition by demonstrating visibility into macOS failed logon events. The telemetry captures failed authentication attempts on the endpoint and successfully reports these events to the management console for investigation and response purposes.

Documentation or Evidence:
- [x] Screenshots attached
- [x] Sanitized logs provided
- [ ] Official documentation
- [ ] Private documentation (will share confidentially)

#### Evidence Screenshots

**Management Console Evidence**

The following screenshot confirms that the logon failed telemetry is successfully received and displayed in the C-Prot Management Console (CSC).

<img width="2542" height="1155" alt="C-Prot_macOS_Logon_Failed_CSC_Evidence" src="https://github.com/user-attachments/assets/23964d3c-95b5-4200-8f29-86afb4b08269" />

---

## Type of Contribution

- [x] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information

- **EDR Product Name:** C-Prot EDR
- **EDR Version:** N/A
- **Operating System(s) Tested:** macOS

### Testing Methodology

Logon failed telemetry was validated by performing intentional failed authentication attempts on the macOS endpoint. The corresponding event data was confirmed to be successfully ingested and displayed in the C-Prot Management Console (CSC).

## Additional Notes

All testing was performed in a controlled environment. Any sensitive information present in the screenshots has been sanitized where applicable.

[csc_telemetry_auth-log_2026-05-12T13-04Z_2026-05-12T13-09Z.json.gz](https://github.com/user-attachments/files/27706482/csc_telemetry_auth-log_2026-05-12T13-04Z_2026-05-12T13-09Z.json.gz)
