### PR TITLE
C-Prot Windows USB Device Mount

### DIFF
--- a/EDR_telem_windows.json
+++ b/EDR_telem_windows.json
@@ -1110,7 +1110,7 @@
     "Telemetry Feature Category": null,
     "Sub-Category": "USB Device Mount",
     "BitDefender": "No",
-    "C-Prot": "No",
+    "C-Prot": "Yes",
     "Carbon Black": "Partially",
     "Cortex XDR": "Partially",
     "CrowdStrike": "Yes",


### PR DESCRIPTION
# EDR Telemetry Pull Request

## Contribution Details

This pull request updates and validates **Windows USB Device Mount telemetry** for the C-Prot EDR product. The contribution demonstrates that USB device mount events on a Windows endpoint are correctly detected and ingested into the EDR management platform.

### Telemetry Validation

This contribution meets the EDR Telemetry definition by demonstrating visibility into Windows USB device mount events. The telemetry captures USB device connection and mount activities on the endpoint and successfully reports these events to the management console for investigation and response purposes.

Documentation or Evidence:
- [x] Screenshots attached
- [x] Sanitized logs provided
- [ ] Official documentation
- [ ] Private documentation (will share confidentially)

#### Evidence Screenshots

**Management Console Evidence**

The following screenshot confirms that the USB device mount telemetry is successfully received and displayed in the C-Prot Management Console (CSC).

<img width="2551" height="1140" alt="C-Prot_Windows_Usb_Device_Mount_CSC_Evidence" src="https://github.com/user-attachments/assets/f12bd634-9d96-46cb-a051-f69849969ee3" />

---

## Type of Contribution

- [x] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information

- **EDR Product Name:** C-Prot EDR
- **EDR Version:** N/A
- **Operating System(s) Tested:** Windows

### Testing Methodology

USB device mount telemetry was validated by connecting a USB device to the Windows endpoint. The corresponding event data was confirmed to be successfully ingested and displayed in the C-Prot Management Console (CSC).

## Additional Notes

All testing was performed in a controlled environment. Any sensitive information present in the screenshots has been sanitized where applicable.

[csc_telemetry_all_2026-05-11T14-08Z_2026-05-12T14-08Z.json.gz](https://github.com/user-attachments/files/27706664/csc_telemetry_all_2026-05-11T14-08Z_2026-05-12T14-08Z.json.gz)
