### PR TITLE
C-Prot Windows USB Device Unmount

### DIFF
--- a/EDR_telem_windows.json
+++ b/EDR_telem_windows.json
@@ -1083,7 +1083,7 @@
     "Telemetry Feature Category": null,
     "Sub-Category": "USB Device Unmount",
     "BitDefender": "No",
-    "C-Prot": "No",
+    "C-Prot": "Yes",
     "Carbon Black": "No",
     "Cortex XDR": "Partially",
     "CrowdStrike": "Yes",


### PR DESCRIPTION
# EDR Telemetry Pull Request

## Contribution Details

This pull request updates and validates **Windows USB Device Unmount telemetry** for the C-Prot EDR product. The contribution demonstrates that USB device unmount events on a Windows endpoint are correctly detected and ingested into the EDR management platform.

### Telemetry Validation

This contribution meets the EDR Telemetry definition by demonstrating visibility into Windows USB device unmount events. The telemetry captures USB device disconnection and unmount activities on the endpoint and successfully reports these events to the management console for investigation and response purposes.

Documentation or Evidence:
- [x] Screenshots attached
- [x] Sanitized logs provided
- [ ] Official documentation
- [ ] Private documentation (will share confidentially)

#### Evidence Screenshots

**Management Console Evidence**

The following screenshot confirms that the USB device unmount telemetry is successfully received and displayed in the C-Prot Management Console (CSC).

<img width="2544" height="1135" alt="C-Prot_Windows_Usb_Device_Unmount_CSC_Evidence" src="https://github.com/user-attachments/assets/6595bc8e-edd4-416c-b6a3-d627d2cd752f" />

---

## Type of Contribution

- [x] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information

- **EDR Product Name:** C-Prot EDR
- **EDR Version:** N/A
- **Operating System(s) Tested:** Windows

### Testing Methodology

USB device unmount telemetry was validated by safely ejecting and disconnecting a USB device from the Windows endpoint. The corresponding event data was confirmed to be successfully ingested and displayed in the C-Prot Management Console (CSC).

## Additional Notes

All testing was performed in a controlled environment. Any sensitive information present in the screenshots has been sanitized where applicable.

[csc_telemetry_all_2026-05-11T14-15Z_2026-05-12T14-15Z.json.gz](https://github.com/user-attachments/files/27706877/csc_telemetry_all_2026-05-11T14-15Z_2026-05-12T14-15Z.json.gz)
