### PR TITLE
[Update] Uptycs Linux telemetry: Script Content

### DIFF
--- a/EDR_telem_linux.json
+++ b/EDR_telem_linux.json
@@ -168,7 +168,7 @@
     "Qualys":"No",
     "SentinelOne":"No",
     "Sysmon":"No",
-    "Uptycs":"No"
+    "Uptycs":"Via EnablingTelemetry"
   },
   {
     "Telemetry Feature Category":"Network Activity",


### PR DESCRIPTION
# EDR Telemetry Pull Request

<!-- 
INSTRUCTIONS FOR CONTRIBUTORS (this comment won't appear in the final PR):
1. This template helps you provide all necessary information for your contribution
2. Fill in all relevant sections below
3. Delete any options or sections that don't apply to your contribution
4. For more details, see: https://www.edr-telemetry.com/contribute.html
-->

## Contribution Details

Updating Uptycs Linux telemetry for 1 event category:

- **Script Content**: `No` → `Via EnablingTelemetry`

### Telemetry Validation
<!-- Explain how your contribution meets the EDR Telemetry definition -->

<!-- Check all that apply by replacing [ ] with [x] -->
Documentation or Evidence:
- [ ] Official documentation (link: <!-- add link here -->)
- [x] Screenshots attached
- [ ] Sanitized logs provided
- [ ] Private documentation (will share confidentially)

## Type of Contribution
<!-- Keep only the options that apply to your PR -->

- [x] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information
- EDR Product Name: Uptycs
- EDR Version: 5.22
- Operating System(s) Tested: Linux

## Script Content

Since agent v5.22, Uptycs captures script file contents via the `file_contents` field in the `process_file_events` table. This field is **not enabled by default** and requires explicit configuration to activate, making this `Via EnablingTelemetry`.

The following query was used to confirm the telemetry:

```sql
select upt_time, executable, path, cmdline, file_contents
from process_file_events
where upt_asset_id='REDACTED'
  and upt_day=20260528
  and category='upt_linux_home_directory_edr'
  and file_contents is not null
order by upt_time DESC
```
<img width="1761" height="500" alt="image" src="https://github.com/user-attachments/assets/dacc293c-73b5-43b3-bdc8-3f6e2c568bd9" />
