### PR TITLE
[Update] Uptycs Win telemetry: IMPHASH, BITS Job Activity, VSS Deletion

### DIFF
--- a/EDR_telem_windows.json
+++ b/EDR_telem_windows.json
@@ -698,7 +698,7 @@
     "Sysmon": "Yes",
     "Trellix": "No",
     "Trend Micro": "No",
-    "Uptycs": "No",
+    "Uptycs": "Yes",
     "WatchGuard": "No"
   },
   {
@@ -1184,7 +1184,7 @@
     "Sysmon": "No",
     "Trellix": "Pending Response",
     "Trend Micro": "Pending Response",
-    "Uptycs": "No",
+    "Uptycs": "Yes",
     "WatchGuard": "No"
   },
   {
@@ -1508,7 +1508,7 @@
     "Sysmon": "No",
     "Trellix": "Yes",
     "Trend Micro": "Via EventLogs",
-    "Uptycs": "Via EventLogs",
+    "Uptycs": "Yes",
     "WatchGuard": "No"
   },
   {


### PR DESCRIPTION
# EDR Telemetry Pull Request
<!-- 
INSTRUCTIONS FOR CONTRIBUTORS (this comment won't appear in the final PR):
1. This template helps you provide all necessary information for your contribution
2. Fill in all relevant sections below
3. Delete any options or sections that don't apply to your contribution
4. For more details, see: https://www.edr-telemetry.com/contribute.html
-->

## Contribution Details

<!-- Provide a brief summary of what you're contributing (adding new telemetry, updating existing info, etc.) -->

Updating Uptycs Windows telemetry for 3 event categories, available from agent v5.23:

- **IMPHASH**: `No` → `Yes`
- **BITS Job Activity**: `Via EventLogs` → `Yes`
- **Volume Shadow Copy Deletion**: `No` → `Yes`

### Telemetry Validation
<!-- Explain how your contribution meets the EDR Telemetry definition -->

<!-- Check all that apply by replacing [ ] with [x] -->
Documentation or Evidence:
- [ ] Official documentation (link: <!-- add link here -->)
- [x] Screenshots attached
- [ ] Sanitized logs provided
- [ ] Private documentation (will share confidentially)

## Type of Contribution
<!-- Keep only the options that apply to your PR -->

- [x] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [x] Tool enhancement

## Validation Details

### EDR Product Information
- EDR Product Name: Uptycs
- EDR Version: 5.23
- Operating System(s) Tested: Windows

## IMPHASH

Since agent v5.23, Uptycs captures the `imphash` field via the `process_events` table on Windows, enabled by default. The following query was used to confirm the telemetry:

```sql
select path, exe_name, imphash, md5, sha256 from process_events
```

<img width="1297" height="756" alt="image" src="https://github.com/user-attachments/assets/53f87b70-1a1e-48ee-8357-176b8167e5a3" />

## BITS Job Activity

Since agent v5.23, Uptycs captures BITS job activity via a dedicated `bits_events` table on Windows, enabled by default. This replaces the previous `Via EventLogs` approach (querying `Microsoft-Windows-Bits-Client/Operational` via `windows_events`) with direct native telemetry. The following query was used to confirm the telemetry:

```sql
select * from bits_events
```

<img width="1752" height="425" alt="image" src="https://github.com/user-attachments/assets/7572f225-5dcf-4fcf-938b-5d2c16a2e36b" />

## Volume Shadow Copy Deletion

Since agent v5.23, Uptycs captures Volume Shadow Copy deletion events via the `api_events` table on Windows, enabled by default. The `api_events` table captures multiple VSS-related API calls, including `VSS_DELETE_SNAPSHOT`, `VSS_DELETE_OLDEST_SNAPSHOT`, and `VSS_RESIZE_SNAPSHOT`.

A broad query across all VSS-related API events confirms the coverage:

```sql
select * from api_events where api like '%vss%'
```

<img width="1431" height="1195" alt="image" src="https://github.com/user-attachments/assets/7669cfc3-201f-4ad8-981a-6ee11109b884" />

The following targeted query was used to confirm Volume Shadow Copy deletion specifically:

```sql
select * from api_events where api='VSS_DELETE_OLDEST_SNAPSHOT'
```

<img width="1742" height="532" alt="image" src="https://github.com/user-attachments/assets/3aec3a62-9ede-4c50-8b4a-ab68ca49b016" />