### PR TITLE
[Update] Uptycs macOS telemetry: Device Activity

### DIFF
--- a/EDR_telem_macOS.json
+++ b/EDR_telem_macOS.json
@@ -669,7 +669,7 @@
     "MDE": "Partially",
     "Phorion": "Yes",
     "Qualys": "No",
-    "Uptycs": "No"
+    "Uptycs": "Yes"
   },
   {
     "Telemetry Feature Category": null,
@@ -683,7 +683,7 @@
     "MDE": "Partially",
     "Phorion": "Yes",
     "Qualys": "No",
-    "Uptycs": "No"
+    "Uptycs": "Yes"
   },
   {
     "Telemetry Feature Category": "EDR SysOps",


### PR DESCRIPTION
# EDR Telemetry Pull Request
<!-- 
INSTRUCTIONS FOR CONTRIBUTORS (this comment won't appear in the final PR):
1. This template helps you provide all necessary information for your contribution
2. Fill in all relevant sections below
3. Delete any options or sections that don't apply to your contribution
4. For more details, see: https://www.edr-telemetry.com/contribute.html
-->

## Contribution Details

<!-- Provide a brief summary of what you're contributing (adding new telemetry, updating existing info, etc.) -->

Updating Uptycs macOS telemetry for 2 event categories:

- **External Media Mounted**: `No` → `Yes`
- **External Media Unmounted**: `No` → `Yes`

### Telemetry Validation
<!-- Explain how your contribution meets the EDR Telemetry definition -->

<!-- Check all that apply by replacing [ ] with [x] -->
Documentation or Evidence:
- [ ] Official documentation (link: <!-- add link here -->)
- [x] Screenshots attached
- [ ] Sanitized logs provided
- [ ] Private documentation (will share confidentially)

## Type of Contribution
<!-- Keep only the options that apply to your PR -->

- [x] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information
- EDR Product Name: Uptycs
- EDR Version: 5.19
- Operating System(s) Tested: macOS

## External Media Mounted / External Media Unmounted

Uptycs captures external media mount and unmount events on macOS via the `mounts` table. The `upt_added` field distinguishes the two events: `true` indicates a mount (External Media Mounted) and `false` indicates an unmount (External Media Unmounted).

The following query was used to confirm the telemetry, using a dummy disk image (`EDR_Telemetry_Dummy_image`) as the test volume:

```sql
select upt_hostname, upt_time, upt_added, device, device_alias, path, type
from mounts
where upt_asset_id='REDACTED'
  and upt_day >= CAST(date_format((CURRENT_DATE - INTERVAL '0' DAY), '%Y%m%d') AS INT)
  and path='/Volumes/EDR_Telemetry_Dummy_image'
order by upt_time DESC
limit 1000
```

<img width="1470" height="410" alt="image" src="https://github.com/user-attachments/assets/a8433c23-9475-43ab-8ad8-789147611b47" />