### PR TITLE
[Update] Uptycs Linux telemetry: File Metadata

### DIFF
--- a/EDR_telem_linux.json
+++ b/EDR_telem_linux.json
@@ -624,7 +624,7 @@
     "Qualys":"Pending Response",
     "SentinelOne":"Pending Response",
     "Sysmon":"Pending Response",
-    "Uptycs":"Pending Response"
+    "Uptycs":"Yes"
   },
   {
     "Telemetry Feature Category":null,
@@ -643,6 +643,6 @@
     "Qualys":"Pending Response",
     "SentinelOne":"Pending Response",
     "Sysmon":"Pending Response",
-    "Uptycs":"Pending Response"
+    "Uptycs":"Yes"
   }
 ]


### PR DESCRIPTION
# EDR Telemetry Pull Request
<!-- 
INSTRUCTIONS FOR CONTRIBUTORS (this comment won't appear in the final PR):
1. This template helps you provide all necessary information for your contribution
2. Fill in all relevant sections below
3. Delete any options or sections that don't apply to your contribution
4. For more details, see: https://www.edr-telemetry.com/contribute.html
-->

## Contribution Details

<!-- Provide a brief summary of what you're contributing (adding new telemetry, updating existing info, etc.) -->

Updating Uptycs Linux telemetry for 2 event categories:

- **File Size**: `Pending Response` → `Yes`
- **File Header Bytes**: `Pending Response` → `Yes`

### Telemetry Validation
<!-- Explain how your contribution meets the EDR Telemetry definition -->

<!-- Check all that apply by replacing [ ] with [x] -->
Documentation or Evidence:
- [ ] Official documentation (link: <!-- add link here -->)
- [x] Screenshots attached
- [ ] Sanitized logs provided
- [ ] Private documentation (will share confidentially)

## Type of Contribution
<!-- Keep only the options that apply to your PR -->

- [x] Adding telemetry information for an existing EDR product
- [ ] Adding a new EDR product that meets eligibility criteria
- [ ] Proposing new event categories/sub-categories
- [ ] Documentation improvement
- [ ] Tool enhancement

## Validation Details

### EDR Product Information
- EDR Product Name: Uptycs
- EDR Version: 5.22 (current version - but existed for a long time)
- Operating System(s) Tested: Linux

## File Size

Uptycs captures file size via the `size` field in the `process_file_events` table on Linux, enabled by default. The following query was used to confirm the telemetry:

```sql
select path, size as File_size from process_file_events
where upt_day>0
  and path like '%mal_code_protection.sh%'
  and size >0
order by upt_time DESC
```

<img width="727" height="242" alt="image" src="https://github.com/user-attachments/assets/4f115c1d-96da-48d2-b64b-80e9af653863" />

## File Header Bytes

Uptycs captures file header/magic number information via the `magic_number` field in the `process_file_events` table on Linux, enabled by default. The following query was used to confirm the telemetry:

```sql
select path, magic_number as File_header from process_file_events
where upt_day>0
  and path like '%mal_code_protection.sh%'
  and magic_number is not null
order by upt_time DESC
```

<img width="1512" height="311" alt="image" src="https://github.com/user-attachments/assets/99a835ab-c55e-411c-9046-e9c4f1910971" />
